### PR TITLE
Bugfix/test-expr

### DIFF
--- a/nemu/src/nemu-main.c
+++ b/nemu/src/nemu-main.c
@@ -15,7 +15,6 @@
 
 #include "monitor/sdb/sdb.h"
 #include <common.h>
-#include <stdio.h>
 
 void init_monitor(int, char *[]);
 void am_init_monitor();

--- a/nemu/tools/gen-expr/gen-expr.c
+++ b/nemu/tools/gen-expr/gen-expr.c
@@ -137,7 +137,8 @@ int main(int argc, char *argv[]) {
     fputs(code_buf, fp);
     fclose(fp);
 
-    int ret = system("gcc -Wall /tmp/.code.c -o /tmp/.expr");
+    int ret =
+        system("gcc -Wall -Werror /tmp/.code.c -o /tmp/.expr");
     if (ret != 0) {
       fprintf(stderr, "flitered!\n");
       i--;


### PR DESCRIPTION
1. Add `-Werror` to gcc command in `tools/gen-expr` convert warning to error to prevent generate illegal tests such as div-by-zero and overflow;
2. Move `test_expr` in main function out of the emulator logic to make it more reasonalble;
3. Improve error handling of `text_expr` .